### PR TITLE
Add basic Space Invaders-style game

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,167 +1,36 @@
-.page {
-  --gray-rgb: 0, 0, 0;
-  --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
-  --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
-
-  --button-primary-hover: #383838;
-  --button-secondary-hover: #f2f2f2;
-
-  display: grid;
-  grid-template-rows: 20px 1fr 20px;
-  align-items: center;
-  justify-items: center;
-  min-height: 100svh;
-  padding: 80px;
-  gap: 64px;
-  font-family: var(--font-geist-sans);
+.gameContainer {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  background: black;
+  overflow: hidden;
 }
 
-@media (prefers-color-scheme: dark) {
-  .page {
-    --gray-rgb: 255, 255, 255;
-    --gray-alpha-200: rgba(var(--gray-rgb), 0.145);
-    --gray-alpha-100: rgba(var(--gray-rgb), 0.06);
-
-    --button-primary-hover: #ccc;
-    --button-secondary-hover: #1a1a1a;
-  }
+.canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
-.main {
+.controls {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
   display: flex;
-  flex-direction: column;
-  gap: 32px;
-  grid-row-start: 2;
+  gap: 10px;
 }
 
-.main ol {
-  font-family: var(--font-geist-mono);
-  padding-left: 0;
-  margin: 0;
-  font-size: 14px;
-  line-height: 24px;
-  letter-spacing: -0.01em;
-  list-style-position: inside;
-}
-
-.main li:not(:last-of-type) {
-  margin-bottom: 8px;
-}
-
-.main code {
-  font-family: inherit;
-  background: var(--gray-alpha-100);
-  padding: 2px 4px;
+.controlButton {
+  width: 40px;
+  height: 40px;
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: 1px solid white;
   border-radius: 4px;
-  font-weight: 600;
+  font-size: 20px;
 }
 
-.ctas {
-  display: flex;
-  gap: 16px;
+.controlButton:active {
+  background: rgba(255, 255, 255, 0.4);
 }
 
-.ctas a {
-  appearance: none;
-  border-radius: 128px;
-  height: 48px;
-  padding: 0 20px;
-  border: 1px solid transparent;
-  transition:
-    background 0.2s,
-    color 0.2s,
-    border-color 0.2s;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: 500;
-}
-
-a.primary {
-  background: var(--foreground);
-  color: var(--background);
-  gap: 8px;
-}
-
-a.secondary {
-  border-color: var(--gray-alpha-200);
-  min-width: 158px;
-}
-
-.footer {
-  grid-row-start: 3;
-  display: flex;
-  gap: 24px;
-}
-
-.footer a {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.footer img {
-  flex-shrink: 0;
-}
-
-/* Enable hover only on non-touch devices */
-@media (hover: hover) and (pointer: fine) {
-  a.primary:hover {
-    background: var(--button-primary-hover);
-    border-color: transparent;
-  }
-
-  a.secondary:hover {
-    background: var(--button-secondary-hover);
-    border-color: transparent;
-  }
-
-  .footer a:hover {
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
-}
-
-@media (max-width: 600px) {
-  .page {
-    padding: 32px;
-    padding-bottom: 80px;
-  }
-
-  .main {
-    align-items: center;
-  }
-
-  .main ol {
-    text-align: center;
-  }
-
-  .ctas {
-    flex-direction: column;
-  }
-
-  .ctas a {
-    font-size: 14px;
-    height: 40px;
-    padding: 0 16px;
-  }
-
-  a.secondary {
-    min-width: auto;
-  }
-
-  .footer {
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .logo {
-    filter: invert();
-  }
-}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-import { useEffect, useRef } from "react";
-import styles from "./page.module.css";
+import { useEffect, useRef } from 'react';
+import styles from './page.module.css';
 
 export default function Home() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -10,7 +10,7 @@ export default function Home() {
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext("2d");
+    const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
     const width = canvas.width;
@@ -34,26 +34,26 @@ export default function Home() {
 
     const invaderData = [
       {
-        src: "https://upload.wikimedia.org/wikipedia/commons/a/a5/Instagram_icon.png",
-        url: "https://www.instagram.com",
+        src: 'https://upload.wikimedia.org/wikipedia/commons/a/a5/Instagram_icon.png',
+        url: 'https://www.instagram.com',
       },
       {
-        src: "https://upload.wikimedia.org/wikipedia/commons/4/44/Facebook_Logo.png",
-        url: "https://www.facebook.com",
+        src: 'https://upload.wikimedia.org/wikipedia/commons/4/44/Facebook_Logo.png',
+        url: 'https://www.facebook.com',
       },
       {
-        src: "https://upload.wikimedia.org/wikipedia/fr/c/c8/Twitter_Bird.svg",
-        url: "https://twitter.com",
+        src: 'https://upload.wikimedia.org/wikipedia/commons/a/a5/Instagram_icon.png',
+        url: 'https://www.instagram.com',
       },
       {
-        src: "https://upload.wikimedia.org/wikipedia/commons/9/9f/Youtube_logo.png",
-        url: "https://www.youtube.com",
+        src: 'https://upload.wikimedia.org/wikipedia/commons/4/44/Facebook_Logo.png',
+        url: 'https://www.facebook.com',
       },
     ];
 
     const invaders = invaderData.map((data, i) => {
       const img = new Image();
-      img.crossOrigin = "anonymous";
+      img.crossOrigin = 'anonymous';
       const inv = {
         x: 80 + i * 120,
         y: 60,
@@ -84,14 +84,14 @@ export default function Home() {
     }
 
     function keyDown(e: KeyboardEvent) {
-      if (e.key === "ArrowLeft") keys.current.left = true;
-      if (e.key === "ArrowRight") keys.current.right = true;
+      if (e.key === 'ArrowLeft') keys.current.left = true;
+      if (e.key === 'ArrowRight') keys.current.right = true;
     }
 
     function keyUp(e: KeyboardEvent) {
-      if (e.key === "ArrowLeft") keys.current.left = false;
-      if (e.key === "ArrowRight") keys.current.right = false;
-      if (e.key === "ArrowUp") shoot();
+      if (e.key === 'ArrowLeft') keys.current.left = false;
+      if (e.key === 'ArrowRight') keys.current.right = false;
+      if (e.key === 'ArrowUp') shoot();
     }
 
     function update() {
@@ -114,7 +114,7 @@ export default function Home() {
             b.y < inv.y + inv.height &&
             b.y + b.height > inv.y
           ) {
-            window.open(inv.url, "_blank");
+            window.open(inv.url, '_blank');
             invaders.splice(j, 1);
             bullets.splice(i, 1);
             break bulletsLoop;
@@ -126,10 +126,10 @@ export default function Home() {
     function draw() {
       ctx.clearRect(0, 0, width, height);
 
-      ctx.fillStyle = "white";
+      ctx.fillStyle = 'white';
       ctx.fillRect(player.x, player.y, player.width, player.height);
 
-      ctx.fillStyle = "red";
+      ctx.fillStyle = 'red';
       bullets.forEach((b) => ctx.fillRect(b.x, b.y, b.width, b.height));
 
       invaders.forEach((inv) => {
@@ -147,11 +147,11 @@ export default function Home() {
 
     loop();
 
-    window.addEventListener("keydown", keyDown);
-    window.addEventListener("keyup", keyUp);
+    window.addEventListener('keydown', keyDown);
+    window.addEventListener('keyup', keyUp);
     return () => {
-      window.removeEventListener("keydown", keyDown);
-      window.removeEventListener("keyup", keyUp);
+      window.removeEventListener('keydown', keyDown);
+      window.removeEventListener('keyup', keyUp);
     };
   }, []);
 
@@ -193,4 +193,3 @@ export default function Home() {
     </div>
   );
 }
-

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,15 +54,23 @@ export default function Home() {
     const invaders = invaderData.map((data, i) => {
       const img = new Image();
       img.crossOrigin = "anonymous";
-      img.src = data.src;
-      return {
+      const inv = {
         x: 80 + i * 120,
         y: 60,
         width: 50,
         height: 50,
         img,
         url: data.url,
+        loaded: false,
       };
+      img.onload = () => {
+        inv.loaded = true;
+      };
+      img.onerror = () => {
+        console.error(`Failed to load image: ${data.src}`);
+      };
+      img.src = data.src;
+      return inv;
     });
 
     function shoot() {
@@ -125,7 +133,7 @@ export default function Home() {
       bullets.forEach((b) => ctx.fillRect(b.x, b.y, b.width, b.height));
 
       invaders.forEach((inv) => {
-        if (inv.img.complete) {
+        if (inv.loaded) {
           ctx.drawImage(inv.img, inv.x, inv.y, inv.width, inv.height);
         }
       });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,95 +1,188 @@
-import Image from "next/image";
+"use client";
+
+import { useEffect, useRef } from "react";
 import styles from "./page.module.css";
 
 export default function Home() {
-  return (
-    <div className={styles.page}>
-      <main className={styles.main}>
-        <Image
-          className={styles.logo}
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol>
-          <li>
-            Get started by editing <code>src/app/page.tsx</code>.
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const keys = useRef({ left: false, right: false });
 
-        <div className={styles.ctas}>
-          <a
-            className={styles.primary}
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className={styles.logo}
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.secondary}
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className={styles.footer}>
-        <a
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const width = canvas.width;
+    const height = canvas.height;
+
+    const player = {
+      x: width / 2 - 20,
+      y: height - 40,
+      width: 40,
+      height: 20,
+      speed: 5,
+    };
+
+    const bullets: {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      speed: number;
+    }[] = [];
+
+    const invaderData = [
+      {
+        src: "https://upload.wikimedia.org/wikipedia/commons/a/a5/Instagram_icon.png",
+        url: "https://www.instagram.com",
+      },
+      {
+        src: "https://upload.wikimedia.org/wikipedia/commons/4/44/Facebook_Logo.png",
+        url: "https://www.facebook.com",
+      },
+      {
+        src: "https://upload.wikimedia.org/wikipedia/fr/c/c8/Twitter_Bird.svg",
+        url: "https://twitter.com",
+      },
+      {
+        src: "https://upload.wikimedia.org/wikipedia/commons/9/9f/Youtube_logo.png",
+        url: "https://www.youtube.com",
+      },
+    ];
+
+    const invaders = invaderData.map((data, i) => {
+      const img = new Image();
+      img.crossOrigin = "anonymous";
+      img.src = data.src;
+      return {
+        x: 80 + i * 120,
+        y: 60,
+        width: 50,
+        height: 50,
+        img,
+        url: data.url,
+      };
+    });
+
+    function shoot() {
+      bullets.push({
+        x: player.x + player.width / 2 - 2,
+        y: player.y,
+        width: 4,
+        height: 10,
+        speed: 7,
+      });
+    }
+
+    function keyDown(e: KeyboardEvent) {
+      if (e.key === "ArrowLeft") keys.current.left = true;
+      if (e.key === "ArrowRight") keys.current.right = true;
+    }
+
+    function keyUp(e: KeyboardEvent) {
+      if (e.key === "ArrowLeft") keys.current.left = false;
+      if (e.key === "ArrowRight") keys.current.right = false;
+      if (e.key === "ArrowUp") shoot();
+    }
+
+    function update() {
+      if (keys.current.left) player.x -= player.speed;
+      if (keys.current.right) player.x += player.speed;
+      player.x = Math.max(0, Math.min(width - player.width, player.x));
+
+      bullets.forEach((b) => (b.y -= b.speed));
+      for (let i = bullets.length - 1; i >= 0; i--) {
+        if (bullets[i].y + bullets[i].height < 0) bullets.splice(i, 1);
+      }
+
+      bulletsLoop: for (let i = bullets.length - 1; i >= 0; i--) {
+        const b = bullets[i];
+        for (let j = 0; j < invaders.length; j++) {
+          const inv = invaders[j];
+          if (
+            b.x < inv.x + inv.width &&
+            b.x + b.width > inv.x &&
+            b.y < inv.y + inv.height &&
+            b.y + b.height > inv.y
+          ) {
+            window.open(inv.url, "_blank");
+            invaders.splice(j, 1);
+            bullets.splice(i, 1);
+            break bulletsLoop;
+          }
+        }
+      }
+    }
+
+    function draw() {
+      ctx.clearRect(0, 0, width, height);
+
+      ctx.fillStyle = "white";
+      ctx.fillRect(player.x, player.y, player.width, player.height);
+
+      ctx.fillStyle = "red";
+      bullets.forEach((b) => ctx.fillRect(b.x, b.y, b.width, b.height));
+
+      invaders.forEach((inv) => {
+        if (inv.img.complete) {
+          ctx.drawImage(inv.img, inv.x, inv.y, inv.width, inv.height);
+        }
+      });
+    }
+
+    function loop() {
+      update();
+      draw();
+      requestAnimationFrame(loop);
+    }
+
+    loop();
+
+    window.addEventListener("keydown", keyDown);
+    window.addEventListener("keyup", keyUp);
+    return () => {
+      window.removeEventListener("keydown", keyDown);
+      window.removeEventListener("keyup", keyUp);
+    };
+  }, []);
+
+  const startLeft = () => (keys.current.left = true);
+  const stopLeft = () => (keys.current.left = false);
+  const startRight = () => (keys.current.right = true);
+  const stopRight = () => (keys.current.right = false);
+
+  return (
+    <div className={styles.gameContainer}>
+      <canvas
+        ref={canvasRef}
+        width={800}
+        height={600}
+        className={styles.canvas}
+      />
+      <div className={styles.controls}>
+        <button
+          className={styles.controlButton}
+          onMouseDown={startLeft}
+          onMouseUp={stopLeft}
+          onMouseLeave={stopLeft}
+          onTouchStart={startLeft}
+          onTouchEnd={stopLeft}
         >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
+          ◀
+        </button>
+        <button
+          className={styles.controlButton}
+          onMouseDown={startRight}
+          onMouseUp={stopRight}
+          onMouseLeave={stopRight}
+          onTouchStart={startRight}
+          onTouchEnd={stopRight}
         >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+          ▶
+        </button>
+      </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- Replace default Next.js page with a simple Space Invaders game using canvas
- Add on-screen left/right controls and arrow key support with shooting on key up
- Targets use social media logos that open their sites when hit

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ae4a84c588324ae473e54f9f6d048