### PR TITLE
feat: introduce typed targets with dialogs

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import styles from "./page.module.css";
+import DialogTarget from "@/targets/DialogTarget";
+import LinkTarget from "@/targets/LinkTarget";
+import DeadTarget from "@/targets/DeadTarget";
+import Target from "@/targets/Target";
+import BaseInfoDialog from "@/components/dialogs/BaseInfoDialog";
+import ProjectsDialog from "@/components/dialogs/ProjectsDialog";
 
 export default function Home() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const keys = useRef({ left: false, right: false });
+  const [dialog, setDialog] = useState<"base" | "projects" | null>(null);
+
+  const targets = useRef<Target[]>([]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -43,54 +52,46 @@ export default function Home() {
       speed: number;
     }[] = [];
 
-    const invaderData = [
+    const targetData = [
       {
-        src: "https://upload.wikimedia.org/wikipedia/commons/a/a5/Instagram_icon.png",
+        type: "dialog" as const,
+        src: "https://img.icons8.com/ios-filled/50/info.png",
+        action: () => setDialog("base"),
+      },
+      {
+        type: "dialog" as const,
+        src: "https://img.icons8.com/ios-filled/50/code-file.png",
+        action: () => setDialog("projects"),
+      },
+      {
+        type: "link" as const,
+        src: "https://img.icons8.com/ios-filled/50/instagram-new.png",
         url: "https://www.instagram.com",
       },
       {
-        src: "https://upload.wikimedia.org/wikipedia/commons/4/44/Facebook_Logo.png",
-        url: "https://www.facebook.com",
-      },
-      {
-        src: "https://upload.wikimedia.org/wikipedia/fr/c/c8/Twitter_Bird.svg",
+        type: "link" as const,
+        src: "https://img.icons8.com/ios-filled/50/twitter.png",
         url: "https://twitter.com",
       },
       {
-        src: "https://upload.wikimedia.org/wikipedia/commons/9/9f/Youtube_logo.png",
-        url: "https://www.youtube.com",
+        type: "dead" as const,
+        src: "https://img.icons8.com/ios-filled/50/skull.png",
       },
-      { dead: true },
-      { dead: true },
     ];
 
-    const invaders = invaderData.map((data, i) => {
-      const inv = {
-        x: 20 + i * 30,
-        y: 20,
-        width: 20,
-        height: 14,
-        url: data.url ?? null,
-        dead: !!data.dead,
-        img: null as HTMLImageElement | null,
-        loaded: false,
-      };
-      if (data.src) {
-        const img = new Image();
-        img.crossOrigin = "anonymous";
-        img.onload = () => {
-          inv.loaded = true;
-        };
-        img.onerror = () => {
-          console.error(`Failed to load image: ${data.src}`);
-          inv.loaded = true;
-        };
-        img.src = data.src;
-        inv.img = img;
-      } else {
-        inv.loaded = true;
+    targets.current = targetData.map((data, i) => {
+      const x = 20 + i * 30;
+      const y = 20;
+      const width = 20;
+      const height = 14;
+      switch (data.type) {
+        case "dialog":
+          return new DialogTarget(x, y, width, height, data.src, data.action);
+        case "link":
+          return new LinkTarget(x, y, width, height, data.src, data.url);
+        case "dead":
+          return new DeadTarget(x, y, width, height, data.src);
       }
-      return inv;
     });
 
     function shoot() {
@@ -126,18 +127,16 @@ export default function Home() {
 
       bulletsLoop: for (let i = bullets.length - 1; i >= 0; i--) {
         const b = bullets[i];
-        for (let j = 0; j < invaders.length; j++) {
-          const inv = invaders[j];
+        for (let j = 0; j < targets.current.length; j++) {
+          const t = targets.current[j];
           if (
-            b.x - b.rx < inv.x + inv.width &&
-            b.x + b.rx > inv.x &&
-            b.y - b.ry < inv.y + inv.height &&
-            b.y + b.ry > inv.y
+            b.x - b.rx < t.x + t.width &&
+            b.x + b.rx > t.x &&
+            b.y - b.ry < t.y + t.height &&
+            b.y + b.ry > t.y
           ) {
-            if (inv.url) {
-              window.open(inv.url, "_blank");
-              invaders.splice(j, 1);
-            }
+            t.onHit();
+            targets.current.splice(j, 1);
             bullets.splice(i, 1);
             break bulletsLoop;
           }
@@ -169,37 +168,7 @@ export default function Home() {
         ctx.fill();
       });
 
-      invaders.forEach((inv) => {
-        if (inv.img && inv.loaded) {
-          ctx.save();
-          ctx.beginPath();
-          ctx.ellipse(
-            inv.x + inv.width / 2,
-            inv.y + inv.height / 2,
-            inv.width / 2,
-            inv.height / 2,
-            0,
-            0,
-            Math.PI * 2
-          );
-          ctx.clip();
-          ctx.drawImage(inv.img, inv.x, inv.y, inv.width, inv.height);
-          ctx.restore();
-        } else {
-          ctx.fillStyle = "gray";
-          ctx.beginPath();
-          ctx.ellipse(
-            inv.x + inv.width / 2,
-            inv.y + inv.height / 2,
-            inv.width / 2,
-            inv.height / 2,
-            0,
-            0,
-            Math.PI * 2
-          );
-          ctx.fill();
-        }
-      });
+      targets.current.forEach((t) => t.draw(ctx));
     }
 
     function loop() {
@@ -253,6 +222,8 @@ export default function Home() {
           ▶
         </button>
       </div>
+      {dialog === "base" && <BaseInfoDialog onClose={() => setDialog(null)} />}
+      {dialog === "projects" && <ProjectsDialog onClose={() => setDialog(null)} />}
     </div>
   );
 }

--- a/src/components/dialogs/BaseInfoDialog.tsx
+++ b/src/components/dialogs/BaseInfoDialog.tsx
@@ -1,0 +1,18 @@
+import styles from "./Dialog.module.css";
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function BaseInfoDialog({ onClose }: Props) {
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.dialog}>
+        <p>Base information coming soon...</p>
+        <button className={styles.closeButton} onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dialogs/Dialog.module.css
+++ b/src/components/dialogs/Dialog.module.css
@@ -1,0 +1,23 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.dialog {
+  background: white;
+  padding: 20px;
+  border-radius: 4px;
+  max-width: 300px;
+  text-align: center;
+}
+
+.closeButton {
+  margin-top: 10px;
+}

--- a/src/components/dialogs/ProjectsDialog.tsx
+++ b/src/components/dialogs/ProjectsDialog.tsx
@@ -1,0 +1,18 @@
+import styles from "./Dialog.module.css";
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function ProjectsDialog({ onClose }: Props) {
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.dialog}>
+        <p>Projects coming soon...</p>
+        <button className={styles.closeButton} onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/targets/DeadTarget.ts
+++ b/src/targets/DeadTarget.ts
@@ -1,0 +1,5 @@
+import Target from "./Target";
+
+export default class DeadTarget extends Target {
+  onHit() {}
+}

--- a/src/targets/DialogTarget.ts
+++ b/src/targets/DialogTarget.ts
@@ -1,0 +1,21 @@
+import Target from "./Target";
+
+export default class DialogTarget extends Target {
+  private openDialog: () => void;
+
+  constructor(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    src: string,
+    openDialog: () => void
+  ) {
+    super(x, y, width, height, src);
+    this.openDialog = openDialog;
+  }
+
+  onHit() {
+    this.openDialog();
+  }
+}

--- a/src/targets/LinkTarget.ts
+++ b/src/targets/LinkTarget.ts
@@ -1,0 +1,21 @@
+import Target from "./Target";
+
+export default class LinkTarget extends Target {
+  private url: string;
+
+  constructor(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    src: string,
+    url: string
+  ) {
+    super(x, y, width, height, src);
+    this.url = url;
+  }
+
+  onHit() {
+    window.open(this.url, "_blank");
+  }
+}

--- a/src/targets/Target.ts
+++ b/src/targets/Target.ts
@@ -1,0 +1,65 @@
+export default abstract class Target {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  img: HTMLImageElement | null = null;
+  loaded = false;
+
+  constructor(x: number, y: number, width: number, height: number, src?: string) {
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+
+    if (src) {
+      const img = new Image();
+      img.crossOrigin = "anonymous";
+      img.onload = () => {
+        this.loaded = true;
+      };
+      img.onerror = () => {
+        console.error(`Failed to load image: ${src}`);
+        this.loaded = true;
+      };
+      img.src = src;
+      this.img = img;
+    } else {
+      this.loaded = true;
+    }
+  }
+
+  draw(ctx: CanvasRenderingContext2D) {
+    if (this.img && this.loaded) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.ellipse(
+        this.x + this.width / 2,
+        this.y + this.height / 2,
+        this.width / 2,
+        this.height / 2,
+        0,
+        0,
+        Math.PI * 2
+      );
+      ctx.clip();
+      ctx.drawImage(this.img, this.x, this.y, this.width, this.height);
+      ctx.restore();
+    } else {
+      ctx.fillStyle = "gray";
+      ctx.beginPath();
+      ctx.ellipse(
+        this.x + this.width / 2,
+        this.y + this.height / 2,
+        this.width / 2,
+        this.height / 2,
+        0,
+        0,
+        Math.PI * 2
+      );
+      ctx.fill();
+    }
+  }
+
+  abstract onHit(): void;
+}


### PR DESCRIPTION
## Summary
- add target base class with dialog, link and dead implementations
- show placeholder dialogs for Base Info and Projects
- load target images from new host

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689af65b398c832480002746a1130cca