### PR TITLE
feat: introduce typed targets with dialogs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="de-CH">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         {children}
       </body>

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -35,3 +35,16 @@
   background: rgba(255, 255, 255, 0.4);
 }
 
+.instructions {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  pointer-events: none;
+}
+

--- a/src/components/dialogs/BaseInfoDialog.tsx
+++ b/src/components/dialogs/BaseInfoDialog.tsx
@@ -1,0 +1,18 @@
+import styles from "./Dialog.module.css";
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function BaseInfoDialog({ onClose }: Props) {
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.dialog}>
+        <p>Base information coming soon...</p>
+        <button className={styles.closeButton} onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dialogs/Dialog.module.css
+++ b/src/components/dialogs/Dialog.module.css
@@ -1,0 +1,23 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.dialog {
+  background: white;
+  padding: 20px;
+  border-radius: 4px;
+  max-width: 300px;
+  text-align: center;
+}
+
+.closeButton {
+  margin-top: 10px;
+}

--- a/src/components/dialogs/ProjectsDialog.tsx
+++ b/src/components/dialogs/ProjectsDialog.tsx
@@ -1,0 +1,18 @@
+import styles from "./Dialog.module.css";
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function ProjectsDialog({ onClose }: Props) {
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.dialog}>
+        <p>Projects coming soon...</p>
+        <button className={styles.closeButton} onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/targets/DeadTarget.ts
+++ b/src/targets/DeadTarget.ts
@@ -1,0 +1,5 @@
+import Target from "./Target";
+
+export default class DeadTarget extends Target {
+  onHit() {}
+}

--- a/src/targets/DialogTarget.ts
+++ b/src/targets/DialogTarget.ts
@@ -1,0 +1,21 @@
+import Target from "./Target";
+
+export default class DialogTarget extends Target {
+  private openDialog: () => void;
+
+  constructor(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    src: string,
+    openDialog: () => void
+  ) {
+    super(x, y, width, height, src);
+    this.openDialog = openDialog;
+  }
+
+  onHit() {
+    this.openDialog();
+  }
+}

--- a/src/targets/LinkTarget.ts
+++ b/src/targets/LinkTarget.ts
@@ -1,0 +1,21 @@
+import Target from "./Target";
+
+export default class LinkTarget extends Target {
+  private url: string;
+
+  constructor(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    src: string,
+    url: string
+  ) {
+    super(x, y, width, height, src);
+    this.url = url;
+  }
+
+  onHit() {
+    window.open(this.url, "_blank");
+  }
+}

--- a/src/targets/Target.ts
+++ b/src/targets/Target.ts
@@ -1,0 +1,65 @@
+export default abstract class Target {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  img: HTMLImageElement | null = null;
+  loaded = false;
+
+  constructor(x: number, y: number, width: number, height: number, src?: string) {
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+
+    if (src) {
+      const img = new Image();
+      img.crossOrigin = "anonymous";
+      img.onload = () => {
+        this.loaded = true;
+      };
+      img.onerror = () => {
+        console.error(`Failed to load image: ${src}`);
+        this.loaded = true;
+      };
+      img.src = src;
+      this.img = img;
+    } else {
+      this.loaded = true;
+    }
+  }
+
+  draw(ctx: CanvasRenderingContext2D) {
+    if (this.img && this.loaded) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.ellipse(
+        this.x + this.width / 2,
+        this.y + this.height / 2,
+        this.width / 2,
+        this.height / 2,
+        0,
+        0,
+        Math.PI * 2
+      );
+      ctx.clip();
+      ctx.drawImage(this.img, this.x, this.y, this.width, this.height);
+      ctx.restore();
+    } else {
+      ctx.fillStyle = "gray";
+      ctx.beginPath();
+      ctx.ellipse(
+        this.x + this.width / 2,
+        this.y + this.height / 2,
+        this.width / 2,
+        this.height / 2,
+        0,
+        0,
+        Math.PI * 2
+      );
+      ctx.fill();
+    }
+  }
+
+  abstract onHit(): void;
+}


### PR DESCRIPTION
## Summary
- add target base class with dialog, link and dead implementations
- show placeholder dialogs for Base Info and Projects
- load target images from new host and display typed targets in first row
- fix hydration mismatch by setting root html lang to Swiss German
- use colorful icons, rocket emoji bullets and a shoot button with spacebar support
- display instructions overlay that hides after user input

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689af65b398c832480002746a1130cca