### PR TITLE
Add Docker build and deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.git
+.next
+Dockerfile
+.dockerignore
+npm-debug.log
+**/node_modules

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1.1.0
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            docker pull ghcr.io/${{ github.repository }}:latest
+            docker stop space-invaders || true
+            docker rm space-invaders || true
+            docker run -d --name space-invaders -p 3000:3000 ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Use multi-stage build for smaller image
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and build
+COPY . .
+RUN npm run build
+
+# Production image
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Copy necessary files from builder
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
+# Expose the port used by the Next.js server
+EXPOSE 3000
+
+# Run the Next.js server
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,33 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
+## Docker
+
+To build and run the production image locally:
+
+```bash
+docker build -t space-invaders-portfolio .
+docker run -p 3000:3000 space-invaders-portfolio
+```
+
+The app is then available at [http://localhost:3000](http://localhost:3000).
+
+## Continuous Deployment
+
+This repository includes a GitHub Actions workflow that builds a Docker image and deploys it to a VPS on every push to the `master` branch.
+
+To enable deployments you must configure the following repository secrets:
+
+| Secret | Description |
+| ------ | ----------- |
+| `SSH_HOST` | VPS hostname or IP address |
+| `SSH_USER` | SSH user with permission to run Docker |
+| `SSH_KEY` | Private SSH key for the user |
+
+The workflow publishes the image to GitHub Container Registry at `ghcr.io/<owner>/<repo>:latest` and then pulls and runs the container on your server.
+
+On the VPS the container listens on port `3000` and can be proxied or exposed as needed.
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  /** Enable standalone output for Docker images */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile and ignore files for production image
- enable standalone Next.js build
- create GitHub Actions pipeline that builds/pushes image and deploys via SSH
- document Docker usage and required deployment secrets

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` and `Geist Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_689b2ba56bfc832497e86f11067a072a