### PR TITLE
Ensure canvas context is non-null before drawing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,8 +21,9 @@ export default function Home() {
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    const ctx = context;
     ctx.imageSmoothingEnabled = false;
 
     const width = canvas.width;


### PR DESCRIPTION
## Summary
- prevent null canvas context errors by safely retrieving the drawing context

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689b3f2fef6c8324816e38435d044380