### PR TITLE
feat: improve responsiveness and controls

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,39 +1,56 @@
-.gameContainer {
-  position: relative;
-  width: 100%;
-  height: 100vh;
-  background: black;
-  overflow: hidden;
-}
+ .gameContainer {
+   position: relative;
+   width: 100%;
+   height: 100vh;
+   background: black;
+   overflow: hidden;
+   display: flex;
+   flex-direction: column;
+   justify-content: center;
+   align-items: center;
+ }
 
-.canvas {
-  width: 800px;
-  height: 600px;
-  display: block;
-  image-rendering: pixelated;
-}
+ .canvas {
+   width: 80vw;
+   max-width: 800px;
+   aspect-ratio: 4 / 3;
+   height: auto;
+   display: block;
+   image-rendering: pixelated;
+ }
 
-.controls {
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
-  display: flex;
-  gap: 10px;
-}
+ .controls {
+   position: absolute;
+   bottom: 5%;
+   left: 5%;
+   right: 5%;
+   display: flex;
+   justify-content: space-between;
+   align-items: center;
+ }
 
-.controlButton {
-  width: 40px;
-  height: 40px;
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-  border: 1px solid white;
-  border-radius: 4px;
-  font-size: 20px;
-}
+ .moveControls {
+   display: flex;
+   gap: 5vw;
+ }
 
-.controlButton:active {
-  background: rgba(255, 255, 255, 0.4);
-}
+ .controlButton {
+   width: 12vw;
+   height: 12vw;
+   max-width: 60px;
+   max-height: 60px;
+   min-width: 40px;
+   min-height: 40px;
+   background: rgba(255, 255, 255, 0.2);
+   color: white;
+   border: 1px solid white;
+   border-radius: 4px;
+   font-size: clamp(16px, 6vw, 24px);
+ }
+
+ .controlButton:active {
+   background: rgba(255, 255, 255, 0.4);
+ }
 
 .instructions {
   position: absolute;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -97,6 +97,19 @@ export default function Home() {
       }
     });
 
+    let targetDirection = 1;
+    let targetSteps = 0;
+    const targetInterval = setInterval(() => {
+      targets.current.forEach((t) => {
+        t.x += 10 * targetDirection;
+      });
+      targetSteps++;
+      if (targetSteps === 3) {
+        targetDirection *= -1;
+        targetSteps = 0;
+      }
+    }, 2000);
+
     function shoot() {
       setShowInstructions(false);
       bullets.push({
@@ -191,6 +204,7 @@ export default function Home() {
     return () => {
       window.removeEventListener("keydown", keyDown);
       window.removeEventListener("keyup", keyUp);
+      clearInterval(targetInterval);
     };
   }, []);
 
@@ -223,26 +237,28 @@ export default function Home() {
         </div>
       )}
       <div className={styles.controls}>
-        <button
-          className={styles.controlButton}
-          onMouseDown={startLeft}
-          onMouseUp={stopLeft}
-          onMouseLeave={stopLeft}
-          onTouchStart={startLeft}
-          onTouchEnd={stopLeft}
-        >
-          ◀
-        </button>
-        <button
-          className={styles.controlButton}
-          onMouseDown={startRight}
-          onMouseUp={stopRight}
-          onMouseLeave={stopRight}
-          onTouchStart={startRight}
-          onTouchEnd={stopRight}
-        >
-          ▶
-        </button>
+        <div className={styles.moveControls}>
+          <button
+            className={styles.controlButton}
+            onMouseDown={startLeft}
+            onMouseUp={stopLeft}
+            onMouseLeave={stopLeft}
+            onTouchStart={startLeft}
+            onTouchEnd={stopLeft}
+          >
+            ◀
+          </button>
+          <button
+            className={styles.controlButton}
+            onMouseDown={startRight}
+            onMouseUp={stopRight}
+            onMouseLeave={stopRight}
+            onTouchStart={startRight}
+            onTouchEnd={stopRight}
+          >
+            ▶
+          </button>
+        </div>
         <button
           className={styles.controlButton}
           onMouseDown={handleShoot}


### PR DESCRIPTION
## Summary
- make game canvas and controls responsive using percentages and flex centering
- move targets back and forth to mimic classic space-invader motion
- split mobile controls so movement is on the left and shooting on the right

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts `Geist` and `Geist Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_689b4f889e6c832499df0badb025e2df