### PR TITLE
feat: expand target grid and retro styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,7 +19,7 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-press-start), monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Press_Start_2P } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const pressStart = Press_Start_2P({
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-press-start",
 });
 
 export const metadata: Metadata = {
@@ -24,9 +20,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="de-CH">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
-      </body>
+      <body className={pressStart.className}>{children}</body>
     </html>
   );
 }

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,7 +1,7 @@
  .gameContainer {
    position: relative;
    width: 100%;
-   height: 100vh;
+   min-height: 100dvh;
    background: black;
    overflow: hidden;
    display: flex;
@@ -11,13 +11,14 @@
  }
 
  .canvas {
-   width: 80vw;
-   max-width: 800px;
-   aspect-ratio: 4 / 3;
-   height: auto;
-   display: block;
-   image-rendering: pixelated;
- }
+  width: 80vw;
+  max-width: 800px;
+  aspect-ratio: 4 / 3;
+  height: auto;
+  display: block;
+  image-rendering: pixelated;
+  border: 4px solid white;
+}
 
  .controls {
    position: absolute;
@@ -51,17 +52,24 @@
  .controlButton:active {
    background: rgba(255, 255, 255, 0.4);
  }
+ 
+ .instructions {
+   position: absolute;
+   top: 50%;
+   left: 50%;
+   transform: translate(-50%, -50%);
+   background: rgba(0, 0, 0, 0.7);
+   color: white;
+   padding: 8px 12px;
+   border-radius: 4px;
+   font-size: 14px;
+   text-align: center;
+   pointer-events: none;
+ }
 
-.instructions {
-  position: absolute;
-  top: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(0, 0, 0, 0.7);
-  color: white;
-  padding: 8px 12px;
-  border-radius: 4px;
-  font-size: 14px;
-  pointer-events: none;
-}
+ @media (max-width: 600px) {
+   .canvas {
+     width: 95vw;
+   }
+ }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,8 +4,9 @@ import { useEffect, useRef, useState } from "react";
 import styles from "./page.module.css";
 import DialogTarget from "@/targets/DialogTarget";
 import LinkTarget from "@/targets/LinkTarget";
-import DeadTarget from "@/targets/DeadTarget";
+import DummyTarget from "@/targets/DummyTarget";
 import Target from "@/targets/Target";
+import { TARGET_CONFIG } from "@/targets/targetConfig";
 import BaseInfoDialog from "@/components/dialogs/BaseInfoDialog";
 import ProjectsDialog from "@/components/dialogs/ProjectsDialog";
 
@@ -28,6 +29,11 @@ export default function Home() {
 
     const width = canvas.width;
     const height = canvas.height;
+
+    const stars = Array.from({ length: 40 }, () => ({
+      x: Math.random() * width,
+      y: Math.random() * height,
+    }));
 
     const pixelSize = 2;
     const shipPixels = [
@@ -55,45 +61,27 @@ export default function Home() {
       speed: number;
     }[] = [];
 
-    const targetData = [
-      {
-        type: "dialog" as const,
-        src: "https://img.icons8.com/color/48/info--v1.png",
-        action: () => setDialog("base"),
-      },
-      {
-        type: "dialog" as const,
-        src: "https://img.icons8.com/color/48/code-file.png",
-        action: () => setDialog("projects"),
-      },
-      {
-        type: "link" as const,
-        src: "https://img.icons8.com/color/48/instagram-new.png",
-        url: "https://www.instagram.com",
-      },
-      {
-        type: "link" as const,
-        src: "https://img.icons8.com/color/48/twitter--v1.png",
-        url: "https://twitter.com",
-      },
-      {
-        type: "dead" as const,
-        src: "https://img.icons8.com/color/48/skull.png",
-      },
-    ];
-
-    targets.current = targetData.map((data, i) => {
-      const x = 20 + i * 30;
-      const y = 20;
+    targets.current = TARGET_CONFIG.map((data, i) => {
+      const col = i % 5;
+      const row = Math.floor(i / 5);
+      const x = 20 + col * 30;
+      const y = 20 + row * 30;
       const width = 20;
       const height = 14;
       switch (data.type) {
         case "dialog":
-          return new DialogTarget(x, y, width, height, data.src, data.action);
+          return new DialogTarget(
+            x,
+            y,
+            width,
+            height,
+            data.src,
+            () => setDialog(data.dialog)
+          );
         case "link":
           return new LinkTarget(x, y, width, height, data.src, data.url);
-        case "dead":
-          return new DeadTarget(x, y, width, height, data.src);
+        case "dummy":
+          return new DummyTarget(x, y, width, height);
       }
     });
 
@@ -165,7 +153,13 @@ export default function Home() {
     }
 
     function draw() {
-      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = "black";
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.fillStyle = "white";
+      stars.forEach((s) => {
+        ctx.fillRect(Math.floor(s.x), Math.floor(s.y), 2, 2);
+      });
 
       ctx.fillStyle = "white";
       shipPixels.forEach((row, ry) =>
@@ -181,7 +175,7 @@ export default function Home() {
         })
       );
 
-      ctx.font = "12px serif";
+      ctx.font = "12px 'Press Start 2P', monospace";
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
       bullets.forEach((b) => {
@@ -233,7 +227,8 @@ export default function Home() {
       />
       {showInstructions && (
         <div className={styles.instructions}>
-          Use ◀ ▶ to move, 🚀 or spacebar to shoot
+          <h2>Welcome, pilot!</h2>
+          <p>Use ◀ ▶ to move and 🚀 or spacebar to shoot</p>
         </div>
       )}
       <div className={styles.controls}>

--- a/src/components/dialogs/BaseInfoDialog.tsx
+++ b/src/components/dialogs/BaseInfoDialog.tsx
@@ -8,7 +8,24 @@ export default function BaseInfoDialog({ onClose }: Props) {
   return (
     <div className={styles.overlay}>
       <div className={styles.dialog}>
-        <p>Base information coming soon...</p>
+        <h2>About Me</h2>
+        <p>
+          I&apos;m a self-taught developer who turned a programming hobby into a
+          profession. After studying Digital Business at HAK Bregenz and
+          tackling countless tutorials, internships and projects, I went
+          freelance and co-founded Otiosum – Filmproduktion OG where I work as a
+          1st AC. I&apos;m now studying Technical Mathematics at TU and always
+          exploring new web and full-stack ideas. Curious about our film work?
+          Visit{" "}
+          <a
+            href="https://otiosum-austria.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            otiosum-austria.com
+          </a>
+          .
+        </p>
         <button className={styles.closeButton} onClick={onClose}>
           Close
         </button>

--- a/src/components/dialogs/Dialog.module.css
+++ b/src/components/dialogs/Dialog.module.css
@@ -11,13 +11,18 @@
 }
 
 .dialog {
-  background: white;
+  background: black;
+  color: white;
   padding: 20px;
-  border-radius: 4px;
+  border: 4px solid white;
   max-width: 300px;
   text-align: center;
 }
 
 .closeButton {
   margin-top: 10px;
+  background: black;
+  color: white;
+  border: 2px solid white;
+  padding: 4px 8px;
 }

--- a/src/components/dialogs/ProjectsDialog.tsx
+++ b/src/components/dialogs/ProjectsDialog.tsx
@@ -8,7 +8,13 @@ export default function ProjectsDialog({ onClose }: Props) {
   return (
     <div className={styles.overlay}>
       <div className={styles.dialog}>
-        <p>Projects coming soon...</p>
+        <h2>Projects</h2>
+        <p>
+          I&apos;ve built everything from small full-stack apps to interactive
+          experiments like this game. Freelance work and my role at Otiosum –
+          Filmproduktion OG have given me experience across web, tooling and
+          multimedia film projects. More demos and links will arrive here soon!
+        </p>
         <button className={styles.closeButton} onClick={onClose}>
           Close
         </button>

--- a/src/targets/DeadTarget.ts
+++ b/src/targets/DeadTarget.ts
@@ -1,5 +1,0 @@
-import Target from "./Target";
-
-export default class DeadTarget extends Target {
-  onHit() {}
-}

--- a/src/targets/DummyTarget.ts
+++ b/src/targets/DummyTarget.ts
@@ -1,0 +1,37 @@
+import Target from "./Target";
+
+/**
+ * Dummy targets are simple placeholders that disappear when hit.
+ * They render a small pixelated alien instead of loading an image.
+ */
+export default class DummyTarget extends Target {
+  private static pixels = [
+    [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
+    [0, 1, 0, 1, 1, 0, 1, 0, 0, 0],
+    [1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+    [1, 0, 1, 1, 1, 1, 0, 1, 0, 0],
+    [1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+    [1, 0, 1, 0, 0, 1, 0, 1, 0, 0],
+    [1, 0, 0, 1, 1, 0, 0, 1, 0, 0],
+  ];
+
+  draw(ctx: CanvasRenderingContext2D) {
+    const pixelW = this.width / DummyTarget.pixels[0].length;
+    const pixelH = this.height / DummyTarget.pixels.length;
+    ctx.fillStyle = "white";
+    DummyTarget.pixels.forEach((row, y) =>
+      row.forEach((val, x) => {
+        if (val) {
+          ctx.fillRect(
+            this.x + x * pixelW,
+            this.y + y * pixelH,
+            pixelW,
+            pixelH
+          );
+        }
+      })
+    );
+  }
+
+  onHit() {}
+}

--- a/src/targets/Target.ts
+++ b/src/targets/Target.ts
@@ -20,6 +20,7 @@ export default abstract class Target {
       };
       img.onerror = () => {
         console.error(`Failed to load image: ${src}`);
+        this.img = null;
         this.loaded = true;
       };
       img.src = src;
@@ -30,7 +31,7 @@ export default abstract class Target {
   }
 
   draw(ctx: CanvasRenderingContext2D) {
-    if (this.img && this.loaded) {
+    if (this.img && this.loaded && this.img.naturalWidth > 0) {
       ctx.save();
       ctx.beginPath();
       ctx.ellipse(

--- a/src/targets/targetConfig.ts
+++ b/src/targets/targetConfig.ts
@@ -1,0 +1,66 @@
+export type TargetConfig =
+  | { type: "dialog"; src: string; dialog: "base" | "projects" }
+  | { type: "link"; src: string; url: string }
+  | { type: "dummy" };
+
+// Configuration for the 3x5 grid of targets displayed in the game.
+// Icons are loaded from Icons8 and links can easily be changed here.
+export const TARGET_CONFIG: TargetConfig[] = [
+  // Row 1
+  {
+    type: "dialog",
+    src: "https://img.icons8.com/color/48/info--v1.png",
+    dialog: "base",
+  },
+  {
+    type: "dialog",
+    src: "https://img.icons8.com/color/48/code-file.png",
+    dialog: "projects",
+  },
+  {
+    type: "link",
+    src: "https://img.icons8.com/color/48/instagram-new.png",
+    url: "https://www.instagram.com",
+  },
+  {
+    type: "link",
+    src: "https://img.icons8.com/color/48/twitter--v1.png",
+    url: "https://twitter.com",
+  },
+  {
+    type: "link",
+    src: "https://img.icons8.com/color/48/github.png",
+    url: "https://github.com",
+  },
+
+  // Row 2
+  {
+    type: "link",
+    src: "https://img.icons8.com/color/48/linkedin.png",
+    url: "https://www.linkedin.com",
+  },
+  {
+    type: "link",
+    src: "https://img.icons8.com/color/48/stackoverflow.png",
+    url: "https://stackoverflow.com",
+  },
+  {
+    type: "link",
+    src: "https://img.icons8.com/color/48/film-reel.png",
+    url: "#",
+  },
+  {
+    type: "link",
+    src: "https://img.icons8.com/color/48/briefcase.png",
+    url: "#",
+  },
+  { type: "dummy" },
+
+  // Row 3 - remaining dummy targets
+  { type: "dummy" },
+  { type: "dummy" },
+  { type: "dummy" },
+  { type: "dummy" },
+  { type: "dummy" },
+];
+


### PR DESCRIPTION
## Summary
- add 3x5 target configuration with social links and dummy targets
- draw starry space background with 8-bit font styling
- restyle dialogs and canvas border for arcade look
- avoid canvas errors by skipping broken target images
- render dummy targets as pixel aliens and center the welcome heading
- fill About and Projects dialogs with bio and project info
- improve mobile layout with dynamic viewport height and larger canvas

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Press Start 2P` from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_689bab5a18d48324b2f3ba7908aa8d3a