### PR TITLE
Improve mobile layout and dialog content

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,14 +1,20 @@
- .gameContainer {
-   position: relative;
-   width: 100%;
-   height: 100vh;
-   background: black;
-   overflow: hidden;
-   display: flex;
-   flex-direction: column;
-   justify-content: center;
-   align-items: center;
- }
+.gameContainer {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  background: black;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+@media (max-width: 768px) {
+  .gameContainer {
+    min-height: 130vh;
+  }
+}
 
  .canvas {
    width: 80vw;

--- a/src/components/dialogs/BaseInfoDialog.tsx
+++ b/src/components/dialogs/BaseInfoDialog.tsx
@@ -9,7 +9,26 @@ export default function BaseInfoDialog({ onClose }: Props) {
     <div className={styles.overlay}>
       <div className={styles.dialog}>
         <h2>About</h2>
-        <p>Base information coming soon...</p>
+        <p>
+          Programming went from hobby to profession. Tutorials and the HAK
+          Bregenz Digital Business program gave me a foundation in web and
+          full-stack development.
+        </p>
+        <p>
+          I&apos;m the First Assistant Camera and co-founder of Otiosum -
+          Filmproduktion OG and currently study Technical Mathematics at TU.
+        </p>
+        <p>
+          Learn more at{' '}
+          <a
+            href="https://otiosum-austria.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            otiosum-austria.com
+          </a>
+          .
+        </p>
         <button className={styles.closeButton} onClick={onClose}>
           Close
         </button>

--- a/src/components/dialogs/ProjectsDialog.tsx
+++ b/src/components/dialogs/ProjectsDialog.tsx
@@ -9,7 +9,15 @@ export default function ProjectsDialog({ onClose }: Props) {
     <div className={styles.overlay}>
       <div className={styles.dialog}>
         <h2>Projects</h2>
-        <p>Projects coming soon...</p>
+        <p>
+          I&apos;ve tackled a range of web and full-stack builds, from personal
+          experiments to client-focused apps. I also bring technical know-how to
+          multimedia film projects through Otiosum - Filmproduktion OG.
+        </p>
+        <p>
+          Recent highlights include this Space Invaders portfolio and several
+          small tools that sharpen my development skills.
+        </p>
         <button className={styles.closeButton} onClick={onClose}>
           Close
         </button>


### PR DESCRIPTION
## Summary
- Avoid `100vh` on mobile by switching to `min-height` with a taller mobile viewport.
- Add biography and project details to the About and Projects dialogs.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c4cc169388324a0d6aa08a13ba71a